### PR TITLE
feat: Add GitHub Actions CI for Rust crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ./crate
+
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ./crate


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build and test the Rust crate located in the `crate/` directory.

The workflow is defined in `.github/workflows/rust.yml` and includes the following steps:
- Triggers on push and pull_request to the main branch.
- Checks out the code.
- Builds the crate using `cargo build`.
- Runs tests using `cargo test`.